### PR TITLE
Improved eraser implementation

### DIFF
--- a/QtPaintTest/QtPaintTest/DrawingScene.h
+++ b/QtPaintTest/QtPaintTest/DrawingScene.h
@@ -63,6 +63,8 @@ private:
     void updateEraserStroke(const QPointF& pos);
     void finalizeEraserStroke();
     void processEraserOnStroke(StrokeItem* stroke, const Clipper2Lib::Path64& eraserPath);
+    QList<QPainterPath> findDisconnectedComponents(const QPainterPath& complexPath);
+    bool subpathsIntersect(const QPainterPath& path1, const QPainterPath& path2);
 
     // Fill Implementation
     void applyFill(const QPointF& pos);


### PR DESCRIPTION
The old eraser implementation did not transform the qt shapes into clipper2 shapes correctly, which resulted in internal shapes being considered outer shapes sometimes which completely broke which parts should be filled or not for complex shapes.

Closes #11 