### PR TITLE
Fixed save dialog coming up even without any changes

### DIFF
--- a/QtPaintTest/QtPaintTest/DrawingManager.h
+++ b/QtPaintTest/QtPaintTest/DrawingManager.h
@@ -93,6 +93,10 @@ public:
 
 	// Undo/Redo functionality
 	void setUndoStack(QUndoStack* stack);
+
+	bool hasModifications() const {
+		return m_undoStack && m_undoStack->canUndo();
+	}
 private:
 
 	DrawingScene* m_scene = nullptr;

--- a/QtPaintTest/QtPaintTest/FileIOOperations.cpp
+++ b/QtPaintTest/QtPaintTest/FileIOOperations.cpp
@@ -51,6 +51,10 @@ void FileIOOperations::saveDrawingAs(QGraphicsScene& scene, MainWindow& window) 
     }
 }
 bool FileIOOperations::maybeSave(QGraphicsScene& scene, MainWindow& window) {
+    if (!DrawingManager::getInstance().hasModifications()) {
+        return true;
+    }
+
     QMessageBox::StandardButton response = QMessageBox::question(
         &window, "Save Changes", "Do you want to save your changes?",
         QMessageBox::Save | QMessageBox::Discard | QMessageBox::Cancel


### PR DESCRIPTION
There is no longer a save dialog when creating a new file or opening a new file when there are no changes to the current file.

Closes #15 