### PR TITLE
Rotation for raster items

### DIFF
--- a/QtPaintTest/QtPaintTest/QtPaintTest.vcxproj
+++ b/QtPaintTest/QtPaintTest/QtPaintTest.vcxproj
@@ -36,7 +36,7 @@
     <Import Project="$(QtMsBuild)\qt_defaults.props" />
   </ImportGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'" Label="QtSettings">
-    <QtInstall>6.8.2_msvc2022_64</QtInstall>
+    <QtInstall>6.10.0_msvc2022_64</QtInstall>
     <QtModules>core;gui;widgets;opengl;openglwidgets;svg;</QtModules>
     <QtBuildConfig>debug</QtBuildConfig>
   </PropertyGroup>

--- a/QtPaintTest/QtPaintTest/RasterItem.cpp
+++ b/QtPaintTest/QtPaintTest/RasterItem.cpp
@@ -1,10 +1,11 @@
 #include "RasterItem.h"
 
 RasterItem::RasterItem(const QImage& image) : BaseItem(), m_image(image) {
-    // Create a rectangle path with the image's aspect ratio
+    // Create a rectangle path with the image's aspect ratio, centered at origin
     if (!m_image.isNull()) {
         QPainterPath path;
-        QRectF rect(0, 0, m_image.width(), m_image.height());
+        QRectF rect(-m_image.width()/2, -m_image.height()/2, 
+                    m_image.width(), m_image.height());
         path.addRect(rect);
         setPath(path);
     }
@@ -13,10 +14,11 @@ RasterItem::RasterItem(const QImage& image) : BaseItem(), m_image(image) {
 RasterItem::RasterItem(const QString& imagePath) : BaseItem() {
     // Load image from path
     m_image.load(imagePath);
-    // Create a rectangle path with the image's aspect ratio
+    // Create a rectangle path with the image's aspect ratio, centered at origin
     if (!m_image.isNull()) {
         QPainterPath path;
-        QRectF rect(0, 0, m_image.width(), m_image.height());
+        QRectF rect(-m_image.width()/2, -m_image.height()/2, 
+                    m_image.width(), m_image.height());
         path.addRect(rect);
         setPath(path);
     }
@@ -40,11 +42,16 @@ BaseItem* RasterItem::clone() const {
 // Override paint method to display the image on the path
 void RasterItem::paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget) {
     Q_UNUSED(widget);
+    Q_UNUSED(option);
 
-    // Draw the image filling the path's bounding rect
+    // Draw the image at the origin of the item's coordinate system
     if (!m_image.isNull()) {
         painter->setRenderHint(QPainter::SmoothPixmapTransform);
-        painter->drawImage(boundingRect(), m_image);
+        
+        // Draw the image centered at the origin to ensure proper rotation
+        QRectF targetRect(-m_image.width()/2, -m_image.height()/2, 
+                          m_image.width(), m_image.height());
+        painter->drawImage(targetRect, m_image);
     }
 
     // Show selection outline if selected

--- a/QtPaintTest/QtPaintTest/SelectTool.cpp
+++ b/QtPaintTest/QtPaintTest/SelectTool.cpp
@@ -803,9 +803,18 @@ void SelectTool::rotateSelection(qreal angle) {
         // Apply new position
         item->setPos(newPos);
 
-        // Apply rotation to the item's transform (if visual rotation is desired)
+        // Apply rotation to the item's transform
         QTransform itemTransform = state.transform;
-        itemTransform.rotate(angle);
+        
+        // For raster items, we need to rotate around the item's center
+        if (dynamic_cast<RasterItem*>(item)) {
+            // Apply rotation to transform matrix (this rotates around origin)
+            itemTransform.rotate(angle);
+        } else {
+            // Standard rotation for vector items
+            itemTransform.rotate(angle);
+        }
+        
         item->setTransform(itemTransform);
 
         // Update stored state
@@ -863,14 +872,37 @@ void SelectTool::applyTransformToItems() {
         // Get current transformation state
         const QPointF currentPos = item->pos();
         const QTransform currentTransform = item->transform();
-        // Apply to original path
-        QPainterPath newPath = currentTransform.map(m_transform.itemStates[item].originalPath);
-        newPath.translate(currentPos);
-
-        item->setPath(newPath);
-        item->setPos(0, 0);
-        item->setTransform(QTransform());
+        
+        // Handle RasterItem differently than vector items
+        if (RasterItem* rasterItem = dynamic_cast<RasterItem*>(item)) {
+            // For raster items, we need to reset the path to maintain proper dimensions
+            // This keeps rotation working correctly regardless of scaling
+            
+            // Get the original dimensions from the original path
+            QPainterPath originalPath = m_transform.itemStates[item].originalPath;
+            QRectF originalBounds = originalPath.boundingRect();
+            
+            // Create a new centered rectangle with original dimensions
+            QPainterPath newPath;
+            newPath.addRect(QRectF(
+                -originalBounds.width()/2, -originalBounds.height()/2,
+                originalBounds.width(), originalBounds.height()
+            ));
+            
+            // Set the path while preserving transformations
+            rasterItem->setPath(newPath);
+            
+            // Keep position and transform matrix intact
+        } 
+        else {
+            // For vector items, apply transform to the path (existing behavior)
+            QPainterPath newPath = currentTransform.map(m_transform.itemStates[item].originalPath);
+            newPath.translate(currentPos);
+            
+            item->setPath(newPath);
+            item->setPos(0, 0);
+            item->setTransform(QTransform());
+        }
     }
     createSelectionBox();
 }
-


### PR DESCRIPTION
The rotation woks perfectly for imported items, however after a lot of distorting using scaling, the item will rotate in an unpredictable way.